### PR TITLE
Fix : Domain-Based Browser Sessions and Automatic Zone Creation

### DIFF
--- a/browser_session.js
+++ b/browser_session.js
@@ -4,87 +4,137 @@ import * as playwright from 'playwright';
 export class Browser_session {
     constructor({cdp_endpoint}){
         this.cdp_endpoint = cdp_endpoint;
+        this._domainSessions = new Map();
     }
 
-    async get_browser({log}={}){
+    _getDomain(url) {
         try {
-            if (this._browser)
+            const urlObj = new URL(url);
+            return urlObj.hostname;
+        } catch(e) {
+            console.error(`Error extracting domain from ${url}:`, e);
+            return 'default';
+        }
+    }
+
+    async _getDomainSession(domain, {log}={}) {
+        if (!this._domainSessions.has(domain)) 
+        {
+            this._domainSessions.set(domain, {
+                browser: null,
+                page: null,
+                browserClosed: true
+            });
+        }
+        return this._domainSessions.get(domain);
+    }
+
+    async get_browser({log, domain='default'}={}){
+        try {
+            const session = await this._getDomainSession(domain, {log});
+            if (session.browser)
             {
-                try { await this._browser.contexts(); }
+                try { await session.browser.contexts(); }
                 catch(e){
-                    log?.(`Browser connection lost (${e.message}), `
+                    log?.(`Browser connection lost for domain ${domain} (${e.message}), `
                         +`reconnecting...`);
-                    this._browser = null;
-                    this._page = null;
-                    this._browserClosed = true;
+                    session.browser = null;
+                    session.page = null;
+                    session.browserClosed = true;
                 }
             }
-            if (!this._browser)
+            if (!session.browser)
             {
-                log?.(`Connecting to Bright Data Scraping Browser.`);
-                this._browser = await playwright.chromium.connectOverCDP(
+                log?.(`Connecting to Bright Data Scraping Browser for domain ${domain}.`);
+                session.browser = await playwright.chromium.connectOverCDP(
                     this.cdp_endpoint);
-                this._browserClosed = false;
-                this._browser.on('disconnected', () => {
-                    log?.('Browser disconnected');
-                    this._browser = null;
-                    this._page = null;
-                    this._browserClosed = true;
+                session.browserClosed = false;
+                session.browser.on('disconnected', () => {
+                    log?.(`Browser disconnected for domain ${domain}`);
+                    session.browser = null;
+                    session.page = null;
+                    session.browserClosed = true;
                 });
-                log?.('Connected to Bright Data Scraping Browser');
+                log?.(`Connected to Bright Data Scraping Browser for domain ${domain}`);
             }
-            return this._browser;
+            return session.browser;
         } catch(e){
-            console.error('Error connecting to browser:', e);
-            this._browser = null;
-            this._page = null;
-            this._browserClosed = true;
+            console.error(`Error connecting to browser for domain ${domain}:`, e);
+            const session = this._domainSessions.get(domain);
+            if (session) 
+            {
+                session.browser = null;
+                session.page = null;
+                session.browserClosed = true;
+            }
             throw e;
         }
     }
 
-    async get_page(){
+    async get_page({url=null}={}){
+        const domain = url ? this._getDomain(url) : 'default';
         try {
-            if (this._browserClosed || !this._page)
+            const session = await this._getDomainSession(domain);
+            if (session.browserClosed || !session.page)
             {
-                const browser = await this.get_browser();
+                const browser = await this.get_browser({domain});
                 const existingContexts = browser.contexts();
                 if (existingContexts.length === 0)
                 {
                     const context = await browser.newContext();
-                    this._page = await context.newPage();
+                    session.page = await context.newPage();
                 }
                 else
                 {
                     const existingPages = existingContexts[0]?.pages();
                     if (existingPages && existingPages.length > 0)
-                        this._page = existingPages[0];
+                        session.page = existingPages[0];
                     else
-                        this._page = await existingContexts[0].newPage();
+                        session.page = await existingContexts[0].newPage();
                 }
-                this._browserClosed = false;
-                this._page.once('close', ()=>{
-                    this._page = null;
+                session.browserClosed = false;
+                session.page.once('close', ()=>{
+                    session.page = null;
                 });
             }
-            return this._page;
+            return session.page;
         } catch(e){
-            console.error('Error getting page:', e);
-            this._browser = null;
-            this._page = null;
-            this._browserClosed = true;
+            console.error(`Error getting page for domain ${domain}:`, e);
+            const session = this._domainSessions.get(domain);
+            if (session) 
+            {
+                session.browser = null;
+                session.page = null;
+                session.browserClosed = true;
+            }
             throw e;
         }
     }
 
-    async close(){
-        if (this._browser)
-        {
-            try { await this._browser.close(); }
-            catch(e){ console.error('Error closing browser:', e); }
-            this._browser = null;
-            this._page = null;
-            this._browserClosed = true;
+    async close(domain=null){
+        if (domain) {
+            const session = this._domainSessions.get(domain);
+            if (session && session.browser) 
+            {
+                try { await session.browser.close(); }
+                catch(e){ console.error(`Error closing browser for domain ${domain}:`, e); }
+                session.browser = null;
+                session.page = null;
+                session.browserClosed = true;
+                this._domainSessions.delete(domain);
+            }
+        } else {
+            for (const [domain, session] of this._domainSessions.entries()) {
+                if (session.browser) 
+                {
+                    try { await session.browser.close(); }
+                    catch(e){ console.error(`Error closing browser for domain ${domain}:`, e); }
+                    session.browser = null;
+                    session.page = null;
+                    session.browserClosed = true;
+                }
+            }
+            this._domainSessions.clear();
         }
     }
 }

--- a/browser_session.js
+++ b/browser_session.js
@@ -5,6 +5,7 @@ export class Browser_session {
     constructor({cdp_endpoint}){
         this.cdp_endpoint = cdp_endpoint;
         this._domainSessions = new Map();
+        this._currentDomain = 'default';
     }
 
     _getDomain(url) {
@@ -72,7 +73,11 @@ export class Browser_session {
     }
 
     async get_page({url=null}={}){
-        const domain = url ? this._getDomain(url) : 'default';
+        if (url) 
+        {
+            this._currentDomain = this._getDomain(url);
+        }
+        const domain = this._currentDomain;
         try {
             const session = await this._getDomainSession(domain);
             if (session.browserClosed || !session.page)
@@ -135,6 +140,10 @@ export class Browser_session {
                 }
             }
             this._domainSessions.clear();
+        }
+        if (!domain) 
+        {
+            this._currentDomain = 'default';
         }
     }
 }

--- a/browser_tools.js
+++ b/browser_tools.js
@@ -24,7 +24,7 @@ let scraping_browser_navigate = {
         url: z.string().describe('The URL to navigate to'),
     }),
     execute: async({url})=>{
-        const page = await require_browser().get_page();
+        const page = await require_browser().get_page({url});
         try {
             await page.goto(url, {
                 timeout: 120000,


### PR DESCRIPTION
## Changes

This PR introduces two fixes:

### 1. Domain-Based Browser Sessions

**Problem:** Bright Data imposes a limit of one domain per browser session. The current implementation reuses the same session for multiple domains, causing errors.

**Solution:** Modified the `Browser_session` class to create and maintain separate browser sessions for each domain:
- Added a Map to store sessions by domain
- Implemented domain extraction from URLs
- Updated page management to use domain-specific sessions
- Modified browser tools to pass URLs to the get_page method

### 2. Automatic Zone Creation

**Problem:** Users need to manually create a zone before using the MCP server, which adds setup complexity.

**Solution:** Added functionality to automatically check for and create the required unlocker zone on startup:
- Checks if the configured zone (`mcp_unlocker` by default) exists
- Creates the zone with proper settings if it doesn't exist
- Gracefully handles errors to allow server startup even if zone creation fails

## Testing

Both changes have been tested and work as expected:
- Successfully navigated to multiple domains 
- Confirmed automatic zone creation when not present